### PR TITLE
Remove some unwraps

### DIFF
--- a/src/dll.rs
+++ b/src/dll.rs
@@ -64,12 +64,9 @@ fn shell_change_notify() {
 #[allow(non_snake_case)]
 #[doc(hidden)]
 pub unsafe extern "system" fn DllRegisterServer() -> HRESULT {
-    let module_path = {
-        let result = get_module_path(DLL_INSTANCE);
-        if let Err(err) = result {
-            return err;
-        }
-        result.unwrap()
+    let module_path = match get_module_path(DLL_INSTANCE) {
+        Ok(path) => path,
+        Err(err) => return err,
     };
     if register(&module_path).is_ok() {
         shell_change_notify();

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -31,14 +31,13 @@ impl JXLPropertyStore {
     pub const CLSID: GUID = GUID::from_u128(0x95ffe0f8_ab15_4751_a2f3_cfafdbf13664);
 
     fn get_props(&self) -> windows::core::Result<&IPropertyStoreCache> {
-        if self.props.is_none() {
-            return Err(windows::core::Error::new(
+        match self.props {
+            Some(ref props) => Ok(props),
+            None => Err(windows::core::Error::new(
                 WINCODEC_ERR_NOTINITIALIZED,
                 "Property store not initialized",
-            ));
+            )),
         }
-
-        Ok(self.props.as_ref().unwrap())
     }
 }
 
@@ -66,7 +65,12 @@ impl IInitializeWithStream_Impl for JXLPropertyStore {
             )?
         };
 
-        let props = self.props.as_ref().unwrap();
+        let Some(props) = self.props.as_ref() else {
+            return Err(windows::core::Error::new(
+                WINCODEC_ERR_NOTINITIALIZED,
+                "Property store not initialized",
+            ));
+        };
 
         // XXX: This is copied from um/propkey.h.
         // https://github.com/microsoft/win32metadata/issues/730


### PR DESCRIPTION
While reading the whole codebase to try to understand how to solve the color issue I found some unneeded unwraps.

This don't change any logic since the unwraps they are checked before using them.
This is more a style preference. (I like clean Rust 😄)

One advantage is when searching for unwraps and except, now only the unchecked one are listed.

Follow up on https://github.com/saschanaz/jxl-winthumb/pull/35, need it to be merge before reviewing.