### PR TITLE
Lets *iid match to IInitializeWithStream::IID in IClassFactory::CreateInstance implementation

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -15,7 +15,7 @@ fn basic() {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("alien.jxl", |b| b.iter(|| basic()));
+    c.bench_function("alien.jxl", |b| b.iter(basic));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/dll.rs
+++ b/src/dll.rs
@@ -43,6 +43,10 @@ impl IClassFactory_Impl for ClassFactory_Impl {
                     let unknown: IUnknown = JXLPropertyStore::default().into();
                     unknown.query(iid, object).ok()
                 }
+                windows::Win32::UI::Shell::PropertiesSystem::IInitializeWithStream::IID => {
+                    let unknown: IUnknown = JXLPropertyStore::default().into();
+                    unknown.query(iid, object).ok()
+                }
                 _ => {
                     log::trace!("Unknown IID: {:?}", *iid);
                     E_NOINTERFACE.ok()

--- a/src/dll.rs
+++ b/src/dll.rs
@@ -8,9 +8,11 @@ use crate::{
 use windows as Windows;
 use windows::core::{implement, IUnknown, Interface, GUID, HRESULT};
 use windows::Win32::{
-    Foundation::*, System::Com::IClassFactory_Impl, System::LibraryLoader::GetModuleFileNameW,
-    UI::Shell::PropertiesSystem::{IInitializeWithStream, IPropertyStore},
+    Foundation::*,
+    System::Com::IClassFactory_Impl,
+    System::LibraryLoader::GetModuleFileNameW,
     System::SystemServices::DLL_PROCESS_ATTACH,
+    UI::Shell::PropertiesSystem::{IInitializeWithStream, IPropertyStore},
 };
 
 static mut DLL_INSTANCE: HINSTANCE = HINSTANCE(std::ptr::null_mut());

--- a/src/dll.rs
+++ b/src/dll.rs
@@ -9,6 +9,7 @@ use windows as Windows;
 use windows::core::{implement, IUnknown, Interface, GUID, HRESULT};
 use windows::Win32::{
     Foundation::*, System::Com::IClassFactory_Impl, System::LibraryLoader::GetModuleFileNameW,
+    UI::Shell::PropertiesSystem::{IInitializeWithStream, IPropertyStore},
     System::SystemServices::DLL_PROCESS_ATTACH,
 };
 
@@ -39,11 +40,7 @@ impl IClassFactory_Impl for ClassFactory_Impl {
                     let unknown: IUnknown = JXLWICBitmapDecoder::default().into();
                     unknown.query(iid, object).ok()
                 }
-                windows::Win32::UI::Shell::PropertiesSystem::IPropertyStore::IID => {
-                    let unknown: IUnknown = JXLPropertyStore::default().into();
-                    unknown.query(iid, object).ok()
-                }
-                windows::Win32::UI::Shell::PropertiesSystem::IInitializeWithStream::IID => {
+                IPropertyStore::IID | IInitializeWithStream::IID => {
                     let unknown: IUnknown = JXLPropertyStore::default().into();
                     unknown.query(iid, object).ok()
                 }

--- a/src/winstream.rs
+++ b/src/winstream.rs
@@ -12,7 +12,7 @@ impl<'a> From<&'a IStream> for WinStream<'a> {
     }
 }
 
-impl<'a> Read for WinStream<'a> {
+impl Read for WinStream<'_> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, std::io::Error> {
         let mut bytes_read = 0u32;
         unsafe {


### PR DESCRIPTION
I'm writing something that uses CoCreateInstance to get a property handler that is then initialized.

```rust
   let orig_init_ps: IInitializeWithStream =
        CoCreateInstance(&orig_clsid, None, CLSCTX_INPROC_SERVER)?;
```
This fails with the `E_NOINTERFACE` COM error because it hits the default case of the match in `IClassFactory::CreateInstance`. 

```rust
    _ => {
        log::trace!("Unknown IID: {:?}", *iid);
        E_NOINTERFACE.ok()
     }
```

So I added a match case for IInitializeWithStream:IID.